### PR TITLE
Upgrade dependencies, fix unit tests. Add product_types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 
+before_install:
+  - gem install bundler
+
 rvm:
   - "2.5"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 
 rvm:
-  - "2.1.0"
-  - "2.0.0"
-  - "1.9.3"
+  - "2.5"
+  - "2.7"
 
 script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A gem to interface with the Ecwid REST APIs.
 
 [![Code Climate](https://codeclimate.com/github/davidbiehl/ecwid_api.png)](https://codeclimate.com/github/davidbiehl/ecwid_api)
-[![Build Status](https://travis-ci.org/davidbiehl/ecwid_api.svg?branch=master)](https://travis-ci.org/davidbiehl/ecwid_api)
+[![Build Status](https://travis-ci.org/platehub/ecwid_api.svg?branch=master)](https://travis-ci.org/platehub/ecwid_api)
 
 ## API v3 Warning!
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A gem to interface with the Ecwid REST APIs.
 
-[![Code Climate](https://codeclimate.com/github/davidbiehl/ecwid_api.png)](https://codeclimate.com/github/davidbiehl/ecwid_api)
+[![Maintainability](https://api.codeclimate.com/v1/badges/2de4c62b3dc5f35217a5/maintainability)](https://codeclimate.com/github/platehub/ecwid_api/maintainability)
 [![Build Status](https://travis-ci.org/platehub/ecwid_api.svg?branch=master)](https://travis-ci.org/platehub/ecwid_api)
 
 ## API v3 Warning!

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "ecwid_api"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+def reload!(print = true)
+  puts 'Reloading ...' if print
+  # Main project directory.
+  root_dir = File.expand_path('..', __dir__)
+  # Directories within the project that should be reloaded.
+  reload_dirs = %w{lib}
+  # Loop through and reload every file in all relevant project directories.
+  reload_dirs.each do |dir|
+    Dir.glob("#{root_dir}/#{dir}/**/*.rb").each { |f| load(f) }
+  end
+  # Return true when complete.
+  true
+end
+
+
+require "irb"
+IRB.start(__FILE__)

--- a/ecwid_api.gemspec
+++ b/ecwid_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 0"
-  spec.add_development_dependency "rspec", "~> 2.14", ">= 2.14.1"
+  spec.add_development_dependency "rspec", "~> 3.9.0"
   spec.add_development_dependency "rspec-its", "~> 1.3"
 
   spec.add_dependency "faraday", "~> 1.0.1"

--- a/ecwid_api.gemspec
+++ b/ecwid_api.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 0"
   spec.add_development_dependency "rspec", "~> 2.14", ">= 2.14.1"
 
-  spec.add_dependency "faraday", "~> 0.15.4"
-  spec.add_dependency "faraday_middleware", "~> 0.10.0"
+  spec.add_dependency "faraday", "~> 1.0.1"
+  spec.add_dependency "faraday_middleware", "~> 1.0.0"
 end

--- a/ecwid_api.gemspec
+++ b/ecwid_api.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 0"
   spec.add_development_dependency "rspec", "~> 2.14", ">= 2.14.1"
+  spec.add_development_dependency "rspec-its", "~> 1.3"
 
   spec.add_dependency "faraday", "~> 1.0.1"
   spec.add_dependency "faraday_middleware", "~> 1.0.0"

--- a/ecwid_api.gemspec
+++ b/ecwid_api.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 0"
   spec.add_development_dependency "rspec", "~> 2.14", ">= 2.14.1"
 
-  spec.add_dependency "faraday", "~> 0.9.0"
+  spec.add_dependency "faraday", "~> 0.15.4"
   spec.add_dependency "faraday_middleware", "~> 0.10.0"
 end

--- a/lib/ecwid_api.rb
+++ b/lib/ecwid_api.rb
@@ -23,6 +23,7 @@ module EcwidApi
   require_relative "ecwid_api/product_combination"
 
   require_relative "ecwid_api/product"
+  require_relative "ecwid_api/product_type"
 
   require_relative "ecwid_api/profile"
   require_relative "ecwid_api/storage"

--- a/lib/ecwid_api/api.rb
+++ b/lib/ecwid_api/api.rb
@@ -3,6 +3,7 @@ module EcwidApi
     require_relative "api/base"
     require_relative "api/orders"
     require_relative "api/products"
+    require_relative "api/product_types"
     require_relative "api/categories"
     require_relative "api/product_combinations"
     require_relative "api/customers"

--- a/lib/ecwid_api/api/product_types.rb
+++ b/lib/ecwid_api/api/product_types.rb
@@ -1,0 +1,54 @@
+require_relative "../paged_ecwid_response"
+
+module EcwidApi
+  module Api
+    class ProductTypes < Base
+      # Public: Get all of the ProductType objects for the Ecwid store
+      #
+      # Returns an Array of ProductType objects
+      def all(params = {})
+        response = client.get("classes")
+        return response.body.map do |product_type_hash|
+          ProductType.new(product_type_hash, client: client)          
+        end
+      end
+
+      # Public: Finds a single product_type by product_type ID
+      #
+      # id - an Ecwid product_type ID
+      #
+      # Returns a ProductType object, or nil if one can't be found
+      def find(id)
+        response = client.get("classes/#{id}")
+        if response.success?
+          ProductType.new(response.body, client: client)
+        end
+      end
+
+      # Public: Creates a new ProductType
+      #
+      # params - a Hash
+      #
+      # Raises an Error if there is a problem
+      #
+      # Returns a ProductType object
+      def create(params)
+        response = client.post("classes", params)
+        find(response.body["id"])
+      end
+
+      # Public: Updates an existing ProductType
+      #
+      # id - the Ecwid product_type ID
+      # params - a Hash
+      #
+      # Raises an Error if there is a problem
+      #
+      # Returns a ProductType object
+      def update(id, params)
+        client.put("classes/#{id}", params)
+        find(id)
+      end
+    end
+  end
+end

--- a/lib/ecwid_api/client.rb
+++ b/lib/ecwid_api/client.rb
@@ -54,7 +54,9 @@ module EcwidApi
       "#{DEFAULT_URL}/#{store_id}"
     end
 
-    def_delegators :connection, :get
+    def get(*args, &block)
+      raise_on_failure connection.get(*args, &block)
+    end
 
     def post(*args, &block)
       raise_on_failure connection.post(*args, &block)

--- a/lib/ecwid_api/client.rb
+++ b/lib/ecwid_api/client.rb
@@ -132,6 +132,8 @@ module EcwidApi
     def raise_on_failure(response)
       if response.success?
         response
+      elsif response.status == 404
+        raise NotFoundError.new(response)
       else
         raise ResponseError.new(response)
       end

--- a/lib/ecwid_api/client.rb
+++ b/lib/ecwid_api/client.rb
@@ -20,7 +20,8 @@ module EcwidApi
     attr_reader :token
     attr_reader :adapter
 
-    attr_reader :connection, :profile, :storage, :categories, :orders, :products, :customers, :discount_coupons
+    attr_reader :connection, :profile, :storage, :categories, :orders, :products,
+      :product_types, :customers, :discount_coupons
 
     # Public: Initializes a new Client to interact with the API
     #
@@ -42,10 +43,11 @@ module EcwidApi
         conn.adapter  options[:adapter]
       end
 
-      @categories = Api::Categories.new(self)
-      @orders     = Api::Orders.new(self)
-      @products   = Api::Products.new(self)
-      @customers  = Api::Customers.new(self)
+      @categories       = Api::Categories.new(self)
+      @orders           = Api::Orders.new(self)
+      @products         = Api::Products.new(self)
+      @product_types    = Api::ProductTypes.new(self)
+      @customers        = Api::Customers.new(self)
       @discount_coupons = Api::DiscountCoupons.new(self)
     end
 

--- a/lib/ecwid_api/error.rb
+++ b/lib/ecwid_api/error.rb
@@ -10,4 +10,6 @@ module EcwidApi
       end
     end
   end
+
+  class NotFoundError< ResponseError; end;
 end

--- a/lib/ecwid_api/order.rb
+++ b/lib/ecwid_api/order.rb
@@ -66,7 +66,7 @@ module EcwidApi
     def fulfillment_status=(status)
       status = status.to_s.upcase
       unless VALID_FULFILLMENT_STATUSES.include?(status)
-        raise Error("#{status} is an invalid fullfillment status")
+        raise Error.new("#{status} is an invalid fullfillment status")
       end
       super(status)
     end

--- a/lib/ecwid_api/paged_ecwid_response.rb
+++ b/lib/ecwid_api/paged_ecwid_response.rb
@@ -37,7 +37,6 @@ module EcwidApi
 
       begin
         response = @client.get(@path, params)
-        puts response.body
         items = response.body["items"] || []
         items.each do |item|
           yield(@block ? @block.call(item) : item)

--- a/lib/ecwid_api/paged_ecwid_response.rb
+++ b/lib/ecwid_api/paged_ecwid_response.rb
@@ -37,6 +37,7 @@ module EcwidApi
 
       begin
         response = @client.get(@path, params)
+        puts response.body
         items = response.body["items"] || []
         items.each do |item|
           yield(@block ? @block.call(item) : item)

--- a/lib/ecwid_api/product_type.rb
+++ b/lib/ecwid_api/product_type.rb
@@ -1,0 +1,9 @@
+module EcwidApi
+	class ProductType < Entity
+    self.url_root = "classes"
+
+    ecwid_reader :id, :attributes, :name, :googleTaxonomy
+
+    ecwid_writer :attributes, :name
+	end
+end

--- a/spec/api/orders_spec.rb
+++ b/spec/api/orders_spec.rb
@@ -25,7 +25,7 @@ describe EcwidApi::Api::Orders, faraday: true do
     end
 
     it "is nil when not found" do
-      expect(subject.find(404)).to be_nil
+      expect{subject.find(404)}.to raise_exception(EcwidApi::NotFoundError)
     end
   end
 end

--- a/spec/api/orders_spec.rb
+++ b/spec/api/orders_spec.rb
@@ -6,25 +6,26 @@ describe EcwidApi::Api::Orders, faraday: true do
   describe "#all" do
     it "passes the parameters to the client" do
       expect(client).to receive(:get).with("orders", hash_including(from_date: '1982-05-17'))
-      subject.all(from_date: '1982-05-17')
+        .and_return(empty_pagination_response)
+      subject.all(from_date: '1982-05-17').each{}
     end
 
     it "gets the proper response (see fixtures)" do
-      subject.all.count.should == 2
+      expect(subject.all.count).to be 2
     end
 
     it "gets EcwidApi::Order types" do
-      subject.all.all? { |order| order.is_a?(EcwidApi::Order) }.should be_true
+      expect(subject.all.all? { |order| order.is_a?(EcwidApi::Order) }).to be true
     end
   end
 
   describe "#find" do
     it "is an `EcwidApi::Order`" do
-      subject.find(35).is_a?(EcwidApi::Order).should be_true
+      expect(subject.find(35).is_a?(EcwidApi::Order)).to be true
     end
 
     it "is nil when not found" do
-      subject.find(404).should be_nil
+      expect(subject.find(404)).to be_nil
     end
   end
 end

--- a/spec/api/products_spec.rb
+++ b/spec/api/products_spec.rb
@@ -6,15 +6,16 @@ describe EcwidApi::Api::Products, faraday: true do
   describe "#all" do
     it "passes any other paramters through" do
       expect(client).to receive(:get).with("products", hash_including(from_date: '1982-05-17'))
-      subject.all(from_date: '1982-05-17')
+        .and_return(empty_pagination_response)
+      subject.all(from_date: '1982-05-17').each{}
     end
 
     it "gets the proper response count (see fixture)" do
-      subject.all.count.should == 5
+      expect(subject.all.count).to eq 5
     end
 
     it "gets the proper product (see fixture)" do
-      subject.all.first.sku.should == "NC53090"
+      expect(subject.all.first.sku).to eq"NC53090"
     end
   end
 end

--- a/spec/category_spec.rb
+++ b/spec/category_spec.rb
@@ -27,7 +27,7 @@ describe EcwidApi::Category, faraday: true do
 
       it "returns nil" do
         expect(client.categories).to_not receive(:find)
-        subject.parent.should be_nil
+        expect(subject.parent).to be nil
       end
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -15,7 +15,7 @@ describe EcwidApi::Client do
     end
 
     it "returns a Faraday::Response" do
-      subject.get("categories", parent: 1).is_a?(Faraday::Response).should be_true
+      expect(subject.get("categories", parent: 1).is_a?(Faraday::Response)).to be true
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -10,6 +10,7 @@ describe EcwidApi::Client do
   describe "#get", faraday: true do
     it "delegates to the Faraday connection" do
       expect(subject.send(:connection)).to receive(:get).with("categories", parent: 1)
+        .and_return(double(success?: true, status: 200))
 
       subject.get "categories", parent: 1
     end

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -34,42 +34,42 @@ describe EcwidApi::Entity do
   subject { EntitySubject.new(data) }
 
   describe "::url_root" do
-    its(:url) { should == "stuff/123" }
+    its(:url) { eq "stuff/123" }
 
     context "with a proc" do
       subject { EntityUrlSubject.new(data) }
-      its(:url) { should == "parent/456/and/123" }
+      its(:url) { eq "parent/456/and/123" }
     end
   end
 
 
   describe "#[]" do
     it "gets data with a symbol key" do
-      subject[:id].should == 123
+      expect(subject[:id]).to eq 123
     end
 
     it "gets data with a string key" do
-      subject["parentId"].should == 456
+      expect(subject["parentId"]).to eq 456
     end
 
     it "get nil for unknown data" do
-      subject["whatever"].should be_nil
+      expect(subject["whatever"]).to be nil
     end
 
     it "gets attributes not revealed by ecwid_reader or ecwid_accessor" do
-      subject["hidden"].should == "tee hee"
+      expect(subject["hidden"]).to eq "tee hee"
     end
   end
 
   describe "overrides" do
-    its(:override) { should == "UPCASE ME" }
+    its(:override) { eq "UPCASE ME" }
   end
 
   describe "accessors" do
 
     describe "::ecwid_reader" do
       it "makes data accessible with a snake cased method" do
-        subject.parent_id.should == 456
+        expect(subject.parent_id).to eq 456
       end
 
       it "doesn't have a writer" do
@@ -80,7 +80,7 @@ describe EcwidApi::Entity do
     describe "::ecwid_writer" do
       it "creates a writer method" do
         subject.write_only = "yee haw!"
-        subject["writeOnly"].should == "yee haw!"
+        expect(subject["writeOnly"]).to eq "yee haw!"
       end
 
       it "doesn't have a reader" do
@@ -91,13 +91,13 @@ describe EcwidApi::Entity do
     describe "::ecwid_accessor" do
       it "creates a reader and a writer" do
         subject.the_status = "MATURE"
-        subject.the_status.should == "MATURE"
+        expect(subject.the_status).to eq "MATURE"
       end
     end
 
     describe "without an accessor" do
       it "is accessible with []" do
-        subject[:hidden].should == "tee hee"
+        expect(subject[:hidden]).to eq "tee hee"
       end
 
       it "doesn't have an access method" do

--- a/spec/helpers/client.rb
+++ b/spec/helpers/client.rb
@@ -28,5 +28,16 @@ module Helpers
         builder.adapter :test, faraday_stubs
       end
     end
+
+    # Public: Returns pagination response for empty pages. To stub parameterized requests
+    def empty_pagination_response
+      double(body:{
+        "total"=> 2,
+        "count"=> 2,
+        "offset"=> 0,
+        "limit"=> 100,
+        "items"=> []
+      })
+    end
   end
 end

--- a/spec/oauth_spec.rb
+++ b/spec/oauth_spec.rb
@@ -10,7 +10,7 @@ describe EcwidApi::OAuth do
     end
   end
 
-  its(:oauth_url) { should == "https://my.ecwid.com/api/oauth/authorize?client_id=client_id&scope=scope&response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Foauth" }
+  its(:oauth_url) { eq "https://my.ecwid.com/api/oauth/authorize?client_id=client_id&scope=scope&response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Foauth" }
 
   describe "#access_token(code)" do
     let(:response) do
@@ -30,11 +30,11 @@ describe EcwidApi::OAuth do
     end
 
     it "returns an object that has the access_token" do
-      subject.access_token("code").access_token.should == "the_token"
+      expect(subject.access_token("code").access_token).to eq "the_token"
     end
 
     it "returns an object that has the store_id" do
-      subject.access_token("code").store_id.should == "12345"
+      expect(subject.access_token("code").store_id).to eq "12345"
     end
   end
 end

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -17,45 +17,45 @@ describe EcwidApi::Order, faraday: true do
 
   let(:shipping_person) { nil }
 
-  its(:id) { should == 123 }
+  its(:id) { eq 123 }
 
   describe "#billing_person" do
-    its(:billing_person) { should be_a(EcwidApi::Person) }
+    its(:billing_person) { be_a(EcwidApi::Person) }
 
     it "has the correct data" do
-      subject.billing_person.name.should == "John Doe"
+      expect(subject.billing_person.name).to eq "John Doe"
     end
   end
 
   describe "#shipping_person" do
-    its(:shipping_person) { should be_a(EcwidApi::Person) }
+    its(:shipping_person) { be_a(EcwidApi::Person) }
 
     context "without a shipping person" do
       let(:shipping_person) { nil }
-      its(:shipping_person) { should == subject.billing_person }
+      its(:shipping_person) { eq subject.billing_person }
     end
 
     context "with a shipping person" do
       let(:shipping_person) { {"name" => "Jane Doe"} }
       it "has the correct data" do
-        subject.shipping_person.name.should == "Jane Doe"
+        expect(subject.shipping_person.name).to eq "Jane Doe"
       end
     end
   end
 
   describe "#items" do
     it "has the correct number of items" do
-      subject.items.size.should == 1
+      expect(subject.items.size).to eq 1
     end
 
     it "has the correct data" do
-      subject.items.first.sku.should == "112233"
+      expect(subject.items.first.sku).to eq "112233"
     end
   end
 
   describe "#fulfillment_status=" do
     it "raises an error with an invalid status" do
-      expect { subject.fulfillment_status = :stuff }.to raise_error
+      expect { subject.fulfillment_status = :stuff }.to raise_error(EcwidApi::Error)
     end
 
     it "doesn't raise an error with a valid status" do
@@ -65,7 +65,7 @@ describe EcwidApi::Order, faraday: true do
 
   describe "#fulfillment_status" do
     it "is symbolized" do
-      subject.fulfillment_status.should == :awaiting_processing
+      expect(subject.fulfillment_status).to eq :awaiting_processing
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,11 +5,12 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+require 'rspec/its'
+
 require "ecwid_api"
 require "helpers/client"
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
Updated all gem dependencies to also work for ruby 2.7. Since the gem was giving a conflict with another gem that required a more up to date version of Faraday, and since Faraday was giving deprecation warning.

Also, some of the unit tests were not correctly implemented anymore, these are fixed now as well.

Next to that, this PR adds more robust behavior for get requests by using #raise_on_failure method, instead of directly delegating to Faraday. Also, if a 404 is the status of a response, an exception `NotFoundError < ResponseError` will be raised, which replaces the original behavior where the response would be nil for a call to `#find`, with an unknown ID.

Finally this PR adds the wrapper for "classes", aka "product types" in Ecwid.

P.s. this PR now contains badges for build status en code quality to our fork in Platehub, please consider to update the badges by enabling travis-ci and codeclimate for the repo of Convead and replacing the badges accordingly.